### PR TITLE
Improve portability build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ContinuumOS
 
-ContinuumOS is a light-weight minimal i686 kernel for training purposes.
+ContinuumOS is a light-weight minimal x86 kernel for training purposes. The
+build system can target other architectures by setting the `ARCH` variable.
+An experimental port for the RISC-V RV64GC ISA is included.
 
 ## Features
 
@@ -23,9 +25,9 @@ ContinuumOS is a light-weight minimal i686 kernel for training purposes.
 
 To build and run ContinuumOS, you will need the following tools:
 
-*   An `i686-elf` cross-compiler toolchain (GCC, G++, AS)
+*   A cross-compiler toolchain for your target architecture (defaults to `i686-elf`)
 *   `make`
-*   `qemu-system-i386`
+*   A QEMU binary for your target (e.g. `qemu-system-i386`)
 *   `grub` (for creating the bootable ISO)
 
 ### Building
@@ -36,7 +38,22 @@ To build the kernel, run the following command:
 make all
 ```
 
+You can override the `ARCH` variable to build for another target, for example:
+
+```sh
+make ARCH=x86_64
+
+# Build the experimental RISC-V port
+make ARCH=riscv64
+```
+
 This will create the kernel binary at `kernel/kernel.bin`.
+
+To build every supported port sequentially, run:
+
+```sh
+make check-ports
+```
 
 ### Running
 
@@ -46,13 +63,19 @@ To run the OS in QEMU:
 make run
 ```
 
+For RISC-V:
+
+```sh
+make ARCH=riscv64 run
+```
+
 To create a bootable ISO image and run it in QEMU:
 
 ```sh
 make runiso
 ```
 
-The ISO image will be created as `kernel.iso`.
+The ISO image will be created as `kernel.iso` (x86 only).
 
 ### Cleaning
 

--- a/boot/riscv/boot.s
+++ b/boot/riscv/boot.s
@@ -1,0 +1,14 @@
+.section .text
+.globl _start
+_start:
+    la sp, stack_top
+    call kernel_main
+1:
+    wfi
+    j 1b
+
+.section .bss
+.align 16
+stack_bottom:
+    .skip 16384
+stack_top:

--- a/include/kernel/port_io.h
+++ b/include/kernel/port_io.h
@@ -7,6 +7,7 @@
 extern "C" {
 #endif
 
+#if defined(__i386__) || defined(__x86_64__)
 // Write a byte to a port
 void outb(uint16_t port, uint8_t value);
 
@@ -17,6 +18,13 @@ uint8_t inb(uint16_t port);
 uint16_t inw(uint16_t port);
 
 void io_wait();
+#else
+// Stubs for non-x86 architectures
+static inline void outb(uint16_t, uint8_t) {}
+static inline uint8_t inb(uint16_t) { return 0; }
+static inline uint16_t inw(uint16_t) { return 0; }
+static inline void io_wait(void) {}
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/kernel/port_io.cpp
+++ b/src/kernel/port_io.cpp
@@ -1,5 +1,6 @@
 #include <kernel/port_io.h>
 
+#if defined(__i386__) || defined(__x86_64__)
 // Output a byte to a specified port
 void outb(uint16_t port, uint8_t value) {
     asm volatile("outb %1, %0" :: "dN"(port), "a"(value));
@@ -24,3 +25,10 @@ void io_wait(void) {
     // it might not be strictly necessary, but it's traditional.
     asm volatile ("outb %%al, $0x80" : : "a"(0));
 }
+#else
+// When building for a non-x86 architecture the port I/O functions are stubs.
+void outb(uint16_t, uint8_t) {}
+uint8_t inb(uint16_t) { return 0; }
+uint16_t inw(uint16_t) { return 0; }
+void io_wait(void) {}
+#endif

--- a/src/kernel/vga.cpp
+++ b/src/kernel/vga.cpp
@@ -1,5 +1,8 @@
 #include <kernel/vga.h>
 #include <kernel/port_io.h>
+#if defined(__riscv)
+#include <stdint.h>
+#endif
 
 Terminal::Terminal() : row(0), column(0), color(0), buffer(nullptr) {}
 
@@ -11,7 +14,18 @@ uint16_t Terminal::make_entry(unsigned char uc, uint8_t color) {
     return (uint16_t)uc | ((uint16_t)color << 8);
 }
 
+#if defined(__riscv)
+static volatile uint8_t* const UART = (uint8_t*)0x10000000;
+static void uart_putchar(char c) {
+    while ((UART[5] & 0x20) == 0) {}
+    UART[0] = c;
+}
+#endif
+
 void Terminal::initialize() {
+#if defined(__riscv)
+    (void)UART; // nothing to init
+#else
     row = 0;
     column = 0;
     color = make_color(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
@@ -22,11 +36,16 @@ void Terminal::initialize() {
             buffer[y * VGA_WIDTH + x] = make_entry(' ', color);
         }
     }
+#endif
 }
 
 void Terminal::putentry_at(char c, uint8_t color, size_t x, size_t y) {
+#if defined(__riscv)
+    (void)color; (void)x; (void)y; uart_putchar(c);
+#else
     const size_t index = y * VGA_WIDTH + x;
     buffer[index] = make_entry(c, color);
+#endif
 }
 
 void Terminal::put_at(char c, uint8_t color, size_t x, size_t y) {
@@ -34,11 +53,15 @@ void Terminal::put_at(char c, uint8_t color, size_t x, size_t y) {
 }
 
 void Terminal::update_cursor() {
+#if defined(__riscv)
+    (void)row; (void)column;
+#else
     uint16_t pos = row * VGA_WIDTH + column;
     outb(0x3D4, 0x0F);
     outb(0x3D5, (uint8_t)(pos & 0xFF));
     outb(0x3D4, 0x0E);
     outb(0x3D5, (uint8_t)((pos >> 8) & 0xFF));
+#endif
 }
 
 void Terminal::set_cursor(size_t r, size_t c) {
@@ -48,15 +71,22 @@ void Terminal::set_cursor(size_t r, size_t c) {
 }
 
 void Terminal::new_line() {
+#if defined(__riscv)
+    uart_putchar('\n');
+#else
     column = 0;
     if (++row == VGA_HEIGHT) {
         scroll();
         row = VGA_HEIGHT - 1;
     }
     update_cursor();
+#endif
 }
 
 void Terminal::scroll() {
+#if defined(__riscv)
+    (void)row; (void)column;
+#else
     for (size_t y = 0; y < VGA_HEIGHT - 1; y++) {
         for (size_t x = 0; x < VGA_WIDTH; x++) {
             buffer[y * VGA_WIDTH + x] = buffer[(y + 1) * VGA_WIDTH + x];
@@ -65,9 +95,19 @@ void Terminal::scroll() {
     for (size_t x = 0; x < VGA_WIDTH; x++) {
         buffer[(VGA_HEIGHT - 1) * VGA_WIDTH + x] = make_entry(' ', color);
     }
+#endif
 }
 
 void Terminal::putchar(char c) {
+#if defined(__riscv)
+    if (c == '\n') {
+        uart_putchar('\r');
+        uart_putchar('\n');
+        return;
+    }
+    uart_putchar(c);
+    return;
+#endif
     if (c == '\b') {
         if (column > 0) {
             column--;
@@ -93,7 +133,11 @@ void Terminal::putchar(char c) {
 }
 
 void Terminal::setcolor(uint8_t new_color) {
+#if defined(__riscv)
+    (void)new_color;
+#else
     color = new_color;
+#endif
 }
 
 void Terminal::setfull_color(enum vga_color fg, enum vga_color bg) {
@@ -101,9 +145,16 @@ void Terminal::setfull_color(enum vga_color fg, enum vga_color bg) {
 }
 
 void Terminal::writestring(const char* str) {
+#if defined(__riscv)
     while (*str) {
         putchar(*str++);
     }
+    return;
+#else
+    while (*str) {
+        putchar(*str++);
+    }
+#endif
 }
 
 void Terminal::writeLine(const char* str) {
@@ -112,6 +163,9 @@ void Terminal::writeLine(const char* str) {
 }
 
 void Terminal::clear() {
+#if defined(__riscv)
+    (void)color; row = column = 0;
+#else
     for (size_t y = 0; y < VGA_HEIGHT; y++) {
         for (size_t x = 0; x < VGA_WIDTH; x++) {
             buffer[y * VGA_WIDTH + x] = make_entry(' ', color);
@@ -120,12 +174,21 @@ void Terminal::clear() {
     row = 0;
     column = 0;
     update_cursor();
+#endif
 }
 
 size_t Terminal::get_vga_height() const {
+#if defined(__riscv)
+    return 0;
+#else
     return VGA_HEIGHT;
+#endif
 }
 
 size_t Terminal::get_vga_width() const {
+#if defined(__riscv)
+    return 0;
+#else
     return VGA_WIDTH;
+#endif
 }

--- a/src/riscv/kernel_main.c
+++ b/src/riscv/kernel_main.c
@@ -1,0 +1,23 @@
+#include <stddef.h>
+#include <stdint.h>
+
+static volatile uint8_t* const UART = (uint8_t*)0x10000000;
+
+static void uart_putchar(char c) {
+    while ((UART[5] & 0x20) == 0) {}
+    UART[0] = c;
+}
+
+static void uart_write(const char* s) {
+    while (*s) {
+        if (*s == '\n') uart_putchar('\r');
+        uart_putchar(*s++);
+    }
+}
+
+void kernel_main(void) {
+    uart_write("Hello from ContinuumOS RISC-V\n");
+    while (1) {
+        __asm__ volatile("wfi");
+    }
+}


### PR DESCRIPTION
## Summary
- provide `ARCH_LIST` and `check-ports` target in Makefile
- exclude RISC-V sources when building x86
- document `make check-ports`

## Testing
- `make clean`
- `make all` *(fails: i686-elf-as missing)*
- `make ARCH=riscv64 all` *(fails: riscv64-elf-as missing)*
- `make check-ports` *(fails: i686-elf-as missing)*

------
https://chatgpt.com/codex/tasks/task_e_687821960d28832f9e8257aa047866f4